### PR TITLE
Updating preview command

### DIFF
--- a/commands/preview.js
+++ b/commands/preview.js
@@ -1,24 +1,21 @@
 var path = require('path');
 var site = require(path.join(path.resolve('./'), '/tests/integration/site.json'));
+var qs = require('querystring');
 
 exports.command = function(callback) {
-  var browser = this;
-  var bundleUrl = site.bundleUrl || 'http://localhost:8080';
+    var browser = this;
+    var bundleUrl = site.bundleUrl || 'http://localhost:8080';
 
-  return browser.url('http://preview.mobify.com')
-    .waitForElementPresent('#id_url', 10000, function(){
-        this.setValue('#id_url', site.siteUrl, function() {
-            this.clearValue('#id_site_folder', function() {
-                this.setValue('#id_site_folder', bundleUrl, function() {
-                    this.click('#authorize', function() {
-                        browser.waitForPageToBeMobified(10000, function(result) {
-                            if (typeof callback === 'function') {
-                                callback.call(browser, result);
-                            }
-                        });
-                    });
+    var params = qs.stringify({ url: site.siteUrl, site_folder: bundleUrl });
+
+    return browser.url('http://preview.mobify.com?' + params)
+        .waitForElementPresent('#authorize', 10000, function() {
+            this.click('#authorize', function() {
+                browser.waitForPageToBeMobified(10000, function(result) {
+                    if (typeof callback === 'function') {
+                        callback.call(browser, result);
+                    }
                 });
             });
         });
-    });
 };


### PR DESCRIPTION
Adding site URL and bundle URL as querystring parameters so they are input on the server. Helps speed up our tests.

Status: **Opened for visibility**

Reviewers: @kbingman 
## Changes
- required in querystring module
- changed command to skip inputting and waiting for elements present
## How to test-drive this PR
- open existing project using Nightwatch
- delete nightwatch-commands package
- npm install
- grunt nightwatch
- ensure inputs are filled out when preview loads
