### PR TITLE
added a production flag to avoid using preveiw

### DIFF
--- a/commands/preview.js
+++ b/commands/preview.js
@@ -43,7 +43,10 @@ exports.command = function(url, callback) {
     // that there is an http prefix. The preveiw function doesn't need this, but
     // the browser.get() method does.
     url = url || site.siteUrl;
-    url = url.match(/^http/) ? url : 'http://' + url;
+    
+    if (!url.match(/^http/)) {
+        throw new Error('Site URL must be correctly formatted');
+    }
 
     // If the production flag is set, just runs a `get()` on the URL.
     if (site.production) {


### PR DESCRIPTION
Adds a production flag 

**Status**: _Opened for visibility_

**Reviewers**: @scalvert 
## Changes
- adds a production flag
- checks for `http` in the URL
## How to test-drive this PR
- try an existing suite of tests
- add a production flag. be sure the correct URL is used
