### PR TITLE
Changing preview to use get instead of url

### DIFF
--- a/commands/preview.js
+++ b/commands/preview.js
@@ -50,7 +50,7 @@ exports.command = function(url, callback) {
 
     // If the production flag is set, just runs a `get()` on the URL.
     if (site.production) {
-        return browser.url(url, function(result){
+        return browser.get(url, function(result) {
             if (typeof callback === 'function') {
                 callback.call(browser, result);
             }


### PR DESCRIPTION
Changing preview to use get instead of url when in production mode. This will ensure waitUntilMobified is called.

Status: **Ready to merge**

Reviewers: @kbingman @marlowpayne 
## Changes
- changed the use of url to get in preview.js
## How to test-drive this PR
- nuke your commands and npm install from this branch
- run your tests, they should work
