### PR TITLE
Changing the message for elementsPresent. 

### DIFF
--- a/assertions/elementsPresent.js
+++ b/assertions/elementsPresent.js
@@ -73,16 +73,13 @@ Assertion.prototype.checkElements = function() {
         var msg, passed;
 
         if (result === 0) {
-            var foundMsg = found.map(function(el){
-              return '<' + el + '>';
-            });
-            msg = foundMsg.join(', ') + ' located on page.';
+            msg = util.format('Page contained %s expected element%s.', found.length, found.length > 1 ? 's' : '');
             passed = true;
         } else {
             var missingMsg = missing.map(function(el){
                 return '<' + el + '>';
             });
-            msg = missingMsg.join(', ') + ' missing from page.';
+            msg = util.format('Page missing the following elements: %s.', missingMsg.join(', '));
             passed = false;
         }
 

--- a/tests/src/testElementsPresentAssertion.js
+++ b/tests/src/testElementsPresentAssertion.js
@@ -4,7 +4,7 @@ module.exports = {
         callback();
     },
 
-    'Elements Present found messaging is correct' : function(test) {
+    'Elements Present found messaging is correct for one element' : function(test) {
         var Assertion = require('../../assertions/elementsPresent.js');
 
         var client = {
@@ -23,7 +23,7 @@ module.exports = {
                 test.equals(passed, true);
                 test.equals(result, 0);
                 test.equals(expected, 0);
-                test.equals(msg, '<body> located on page.');
+                test.equals(msg, 'Page contained 1 expected element.');
                 test.equals(abortOnFailure, false);
                 delete Assertion;
                 test.done();
@@ -35,6 +35,40 @@ module.exports = {
         m.client = client;
         m.api = client.api;
         m.command('body');
+    },
+
+    'Elements Present found messaging is correct for multiple elements' : function(test) {
+        var Assertion = require('../../assertions/elementsPresent.js');
+
+        var client = {
+            options: {},
+            api: {
+                element: function(using, selector, callback) {
+                    callback({
+                        status: 0,
+                        value : {
+                            ELEMENT: 'body',
+                            ELEMENT: '.element'
+                        }
+                    });
+                }
+            },
+            assertion : function(passed, result, expected, msg, abortOnFailure) {
+                test.equals(passed, true);
+                test.equals(result, 0);
+                test.equals(expected, 0);
+                test.equals(msg, 'Page contained 2 expected elements.');
+                test.equals(abortOnFailure, false);
+                delete Assertion;
+                test.done();
+            }
+        };
+
+        var m = new Assertion();
+        m.abortOnFailure = true;
+        m.client = client;
+        m.api = client.api;
+        m.command('body', '.element');
     },
 
     'Elements Present not found messaging is correct' : function(test) {
@@ -55,7 +89,7 @@ module.exports = {
                 test.equals(passed, false);
                 test.equals(result, 1);
                 test.equals(expected, 0);
-                test.equals(msg, '<.notfound> missing from page.');
+                test.equals(msg, 'Page missing the following elements: <.notfound>.');
                 test.equals(abortOnFailure, false);
                 delete Assertion;
                 test.done();


### PR DESCRIPTION
Changing the messaging for elementsPresent assertion. The reason behind this is that the success message is too verbose, and really we are only interested in the case where elements fail the test.

Status: **Ready to merge**

Reviewers: @kbingman @marlowpayne @mobify-derrick 
## Changes
- Changed message
- Updated tests to reflect change.
## How to test-drive this PR
- Point to this branch in a project with Nightwatch
- Run your snoop tests
- Ensure the message has changed
