### PR TITLE
updated templateName assertion to give a more helpful error message

### DIFF
--- a/assertions/templateName.js
+++ b/assertions/templateName.js
@@ -42,8 +42,9 @@ Assertion.prototype.checkTemplateName = function() {
 
     this.api.getMobifyEvaluatedData(function(result) {
         if (result) {
-            var passed = result.templateName === expected || result.content.templateName === expected;
-            msg = msg || ('Testing if the page template equals <' + expected + '>.');
+            var actual = result.templateName || result.content.templateName;
+            var passed = actual === expected;
+            msg = msg || ('Testing if the actual page template <' + actual + '> equals the expected <' + expected + '>.');
             self.client.assertion(passed, result, expected, msg, self.abortOnFailure);
             self.emit('complete');
         } else {

--- a/tests/src/testTemplateName.js
+++ b/tests/src/testTemplateName.js
@@ -19,7 +19,7 @@ module.exports = {
                 test.equals(passed, true);
                 test.equals(result.content.templateName, 'home');
                 test.equals(expected, 'home');
-                test.equals(msg, 'Testing if the page template equals <home>.');
+                test.equals(msg, 'Testing if the actual page template <home> equals the expected <home>.');
                 test.equals(abortOnFailure, true);
                 Assertion = null;
                 test.done();
@@ -50,7 +50,7 @@ module.exports = {
                 test.equals(passed, false);
                 test.equals(result.content.templateName, 'main');
                 test.equals(expected, 'home');
-                test.equals(msg, 'Testing if the page template equals <home>.');
+                test.equals(msg, 'Testing if the actual page template <main> equals the expected <home>.');
                 test.equals(abortOnFailure, true);
                 Assertion = null;
                 test.done();


### PR DESCRIPTION
I changed the test message to display both the actual and expected template name. 

Reviewers: @scalvert 
