### PR TITLE
Update nightwatch version to use latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nightwatch-commands",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A set of Mobify specific custom commands for Nightwatch.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump Nightwatch version devDependency to "latest" from "0.4.14"

Status: **Opened for visibility**
Reviewers: @scalvert @marlowpayne @ellenmobify 
## Changes
- Changed nightwatch version to use "latest" from hardcoded value
## Notes
- nightwatch version is really old (0.4.14) updated to use the latest version
