### PR TITLE
Update Selenium Server and Chromedriver versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nightwatch-commands",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A set of Mobify specific custom commands for Nightwatch.js",
   "repository": {
     "type": "git",
@@ -11,7 +11,7 @@
     "url": "https://github.com/mobify/nightwatch-commands/issues"
   },
   "devDependencies": {
-    "nightwatch": "0.5.36",
+    "nightwatch": "0.6.11",
     "nodeunit": "~0.8.4",
     "grunt": "0.4.5",
     "grunt-contrib-jshint": "^0.10.0",

--- a/selenium/installation/conf.js
+++ b/selenium/installation/conf.js
@@ -1,10 +1,10 @@
 var path = require('path');
 
 // see http://selenium-release.storage.googleapis.com/index.html for latest
-var seleniumVersion = '2.40.0';
+var seleniumVersion = '2.45.0';
 
 // see http://chromedriver.storage.googleapis.com/index.html
-var chromeDriverVersion = '2.9';
+var chromeDriverVersion = '2.15';
 
 module.exports = {
   selenium: {


### PR DESCRIPTION
Status: **Ready for Review** 
Owner: Ellen
Reviewers: @mobify-derrick @jgermyn @twangtina @gsaray @chrisjcook 

## Changes
- Use chromedriver 2.15
- Use Selenium server 2.45
- This update is so that we don't fall too far behind in versions.

## Jira Tickets:
- [ ] https://mobify.atlassian.net/browse/CSOPS-1479

## Todos:
- [x] +1

### Feedback:
_none so far_

## How to Test
- In your `package.json`, change the relevant line to `"nightwatch-commands": "git+ssh://git@github.com:mobify/nightwatch-commands.git#update-selenium",`