### PR TITLE
Downgrade chromedriver to 2.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nightwatch-commands",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A set of Mobify specific custom commands for Nightwatch.js",
   "repository": {
     "type": "git",

--- a/selenium/installation/conf.js
+++ b/selenium/installation/conf.js
@@ -4,7 +4,7 @@ var path = require('path');
 var seleniumVersion = '2.45.0';
 
 // see http://chromedriver.storage.googleapis.com/index.html
-var chromeDriverVersion = '2.15';
+var chromeDriverVersion = '2.12';
 
 module.exports = {
   selenium: {


### PR DESCRIPTION
Status: **Ready for Review**
Owner: Ellen
Reviewers: @mobify-derrick 

## Changes
- Downgrade Chromedriver to 2.12 to work with Chrome v38 on CircleCI

## Jira Tickets:
- [x] https://mobify.atlassian.net/browse/CSOPS-1550

## Todos:
- [x] +1

### Feedback:
_none so far_

## How to Test
- In `package.json`: `"nightwatch-commands": "mobify/nightwatch-commands#downgrade-chromedriver"`
- Ensure tests run correctly on CircleCI 