### PR TITLE
htmlCapture Nightwatch command

### DIFF
--- a/commands/htmlCapture.js
+++ b/commands/htmlCapture.js
@@ -1,0 +1,41 @@
+
+var fs = require('fs');
+var mkdirp = require('mkdirp');
+// possibly require library to check for proper naming format ('.html', etc)
+
+var mkdirpSync = function(path) {
+    try {
+        mkdirp.sync(path);
+    } catch(e) {
+        if ( e.code != 'EEXIST' ) throw e;
+    }
+}
+
+exports.command = function(filename, callback) {
+	if (filename && typeof filename !== 'string') {
+        throw new Error('htmlCapture expects first parameter to be string; ' + typeof (fileName) + ' given');
+    }
+
+	var client = this;
+	var filePath = "tests/fixtures/";
+	var messages = {
+	        success: 'Wrote HTML fixture to ' + filePath + fileName + ' after ',
+	        failure: 'Failed to write HTML fixture after '
+	    };
+
+	client.source(function (result){
+        // Source will be stored in result.value. IE:
+        // console.log(result.value);
+
+        // If it doesn't exist, create a path to "tests/fixtures/".
+        mkdirpSync(filePath);
+
+        // Now save result.value to "../../fixtures/contact.html" in order to update the fixture.
+        fs.writeFile(filePath + fileName, result.value, function(error) {
+             if (error) {
+               console.error("write error:  " + error.message);
+             } else {
+               console.log("Successful Write to " + filePath);
+             }
+        });
+    })

--- a/commands/htmlCapture.js
+++ b/commands/htmlCapture.js
@@ -11,19 +11,19 @@ var mkdirpSync = function(path) {
     }
 }
 
-exports.command = function(filename, callback) {
-	if (filename && typeof filename !== 'string') {
+exports.command = function(fileName, callback) {
+    if (fileName && typeof fileName !== 'string') {
         throw new Error('htmlCapture expects first parameter to be string; ' + typeof (fileName) + ' given');
     }
 
-	var client = this;
-	var filePath = "tests/fixtures/";
-	var messages = {
-	        success: 'Wrote HTML fixture to ' + filePath + fileName + ' after ',
-	        failure: 'Failed to write HTML fixture after '
-	    };
+    var client = this;
+    var filePath = "tests/fixtures/";
+    var messages = {
+            success: 'Wrote HTML fixture to ' + filePath + fileName + ' after ',
+            failure: 'Failed to write HTML fixture after '
+        };
 
-	client.source(function (result){
+    client.source(function (result){
         // Source will be stored in result.value. IE:
         // console.log(result.value);
 
@@ -38,4 +38,5 @@ exports.command = function(filename, callback) {
                console.log("Successful Write to " + filePath);
              }
         });
-    })
+    });
+};

--- a/commands/htmlCapture.js
+++ b/commands/htmlCapture.js
@@ -1,7 +1,6 @@
 
 var fs = require('fs');
 var mkdirp = require('mkdirp');
-// possibly require library to check for proper naming format ('.html', etc)
 
 var mkdirpSync = function(path) {
     try {
@@ -16,10 +15,10 @@ exports.command = function(fileName, callback) {
         throw new Error('htmlCapture expects first parameter to be string; ' + typeof (fileName) + ' given');
     }
 
-    var htmlCheck = /^[0-9a-zA-Z]\.html\b/;
+    var htmlCheck = /^\w+\.html$/;
 
-    if (htmlCheck.test(fileName)){
-        throw new Error('htmlCapture expects first parameter to be camelCased string ending with ".html"');
+    if (!htmlCheck.test(fileName)){
+        throw new Error('htmlCapture expects first parameter to be camelCased alphanumberic string ending with ".html"');
     }
 
     var client = this;

--- a/commands/htmlCapture.js
+++ b/commands/htmlCapture.js
@@ -16,10 +16,17 @@ exports.command = function(fileName, callback) {
         throw new Error('htmlCapture expects first parameter to be string; ' + typeof (fileName) + ' given');
     }
 
+    var htmlCheck = /^[0-9a-zA-Z]\.html\b/;
+
+    if (htmlCheck.test(fileName)){
+        throw new Error('htmlCapture expects first parameter to be camelCased string ending with ".html"');
+    }
+
     var client = this;
     var filePath = "tests/fixtures/";
+    var fileLocation = filePath + fileName;
     var messages = {
-            success: 'Wrote HTML fixture to ' + filePath + fileName + ' after ',
+            success: 'Wrote HTML fixture to ' + fileLocation + ' after ',
             failure: 'Failed to write HTML fixture after '
         };
 
@@ -31,11 +38,11 @@ exports.command = function(fileName, callback) {
         mkdirpSync(filePath);
 
         // Now save result.value to "../../fixtures/contact.html" in order to update the fixture.
-        fs.writeFile(filePath + fileName, result.value, function(error) {
+        fs.writeFile(fileLocation, result.value, function(error) {
              if (error) {
                console.error("write error:  " + error.message);
              } else {
-               console.log("Successful Write to " + filePath);
+               console.log("Successful Write to " + fileLocation);
              }
         });
     });

--- a/commands/htmlCapture.js
+++ b/commands/htmlCapture.js
@@ -18,7 +18,7 @@ exports.command = function(fileName, callback) {
     var htmlCheck = /^\w+\.html$/;
 
     if (!htmlCheck.test(fileName)){
-        throw new Error('htmlCapture expects first parameter to be camelCased alphanumberic string ending with ".html"');
+        throw new Error('htmlCapture expects first parameter to be camelCased alphanumeric string ending with ".html"');
     }
 
     var client = this;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/mobify/nightwatch-commands",
   "dependencies": {
+    "mkdirp": "^0.5.1",
     "async": "^0.2.10",
     "chalk": "^0.4.0",
     "mkdirp": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nightwatch-commands",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A set of Mobify specific custom commands for Nightwatch.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Status: **Opened for visibility**

Reviewers: @mobify-derrick @twangtina @ellenmobify @jgermyn @gsaray

To Test:

1.  Create a branch off of any Adaptive project and change the "nightwatch-commands" line in the pacakge.json file to:
> "nightwatch-commands": "git://github.com/mobify/nightwatch-commands.git#nightwatch-commands-htmlcapture"

2.  Run "npm install" to get the new dependencies

3.  In your "nightwatch.json" file, add a new "test_settings" entry for "desktop". This should be the same as your default, but with no "--user-agent" or "--window-size" entries.

4.  You can now use the htmlCapture command in any Nightwatch test. Here is an absolute bare-bones test using the command:
```javascript
module.exports = {
    'home.html Fixture': function(browser) {
        browser
        	.get("http://www.carnival.com")
            .htmlCapture('home.html')
        .end();
    }
};
```

The command will grab and save the HTML of whatever page Nightwatch is currently testing against. It will save the file as whatever you specify in '.htmlCapture("namehere.html")' to the "tests/fixtures/" folder for future integration tests. So for pages that need a workflow to get to, either put the htmlCapture command after the navigation workflow or create a separate, dedicated test with the same workflow (recommended).

Since you'll be creating a separate test to pull HTML fixtures from each page (and therefore each Nightwatch file), it's going to be more manageable to have all of these tests in one place. Also, since we want to be capturing desktop HTML source, we need to use htmlCapture independently of any mobile tests. Currently, I've created a new folder in tests/system/ called "htmlfixtures", which contains two files, "static.js" and "workflow.js". The "static.js" contains pages that are accessible by previewing or navigating to directly, whereas "workflow.js" contains pages like Checkout and Account that need a workflow to get to. Here's what that file structure looks like:

![htmlfixtures-folder](https://cloud.githubusercontent.com/assets/5895392/9142633/e7667762-3cf5-11e5-80d0-05e5bd0dcb3b.png)

*Remember:* Make sure to include your "desktop" environment setting in your nightwatch command. IE:

`grunt nightwatch -test "tests/system/htmlcapture/static.js" -e "desktop"`