### PR TITLE
Update Selenium and Chrome Drivers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nightwatch-commands",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A set of Mobify specific custom commands for Nightwatch.js",
   "repository": {
     "type": "git",
@@ -11,7 +11,7 @@
     "url": "https://github.com/mobify/nightwatch-commands/issues"
   },
   "devDependencies": {
-    "nightwatch": "0.6.11",
+    "nightwatch": "~0.8.6",
     "nodeunit": "~0.8.4",
     "grunt": "0.4.5",
     "grunt-contrib-jshint": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/mobify/nightwatch-commands/issues"
   },
   "devDependencies": {
-    "nightwatch": "~0.8.6",
+    "nightwatch": "0.8.6",
     "nodeunit": "~0.8.4",
     "grunt": "0.4.5",
     "grunt-contrib-jshint": "^0.10.0",

--- a/selenium/installation/conf.js
+++ b/selenium/installation/conf.js
@@ -1,7 +1,7 @@
 var path = require('path');
 
 // see http://selenium-release.storage.googleapis.com/index.html for latest
-var seleniumVersion = '2.48.0';
+var seleniumVersion = '2.48.2';
 
 // see http://chromedriver.storage.googleapis.com/index.html
 var chromeDriverVersion = '2.20';

--- a/selenium/installation/conf.js
+++ b/selenium/installation/conf.js
@@ -1,10 +1,10 @@
 var path = require('path');
 
 // see http://selenium-release.storage.googleapis.com/index.html for latest
-var seleniumVersion = '2.45.0';
+var seleniumVersion = '2.48.0';
 
 // see http://chromedriver.storage.googleapis.com/index.html
-var chromeDriverVersion = '2.12';
+var chromeDriverVersion = '2.20';
 
 module.exports = {
   selenium: {


### PR DESCRIPTION
Update Selenium and Chrome Drivers

Status: **Opened for review**
Reviewers: ** @ellenmobify @marlowpayne @johnboxall  **

## Changes
- Set seleniumVersion to 2.48.2
- Set chromeDriverVersion 2.20

## Checklist
- [x] QA+1
- [x] Eng +1

## How to Test
- Clone a repo with Nightwatch System tests (eg. Matalan)
- In project root package.json point the nightwatch-commands package to "git://github.com/mobify/nightwatch-commands.git#update-selenium-chrome-drivers"
- run `npm install` in terminal for the project
- run `grunt nightwatch -e mobile --tag conversion --retries 1` to run tests (for Matalan only)