### PR TITLE
Make site.json optional

### DIFF
--- a/commands/preview.js
+++ b/commands/preview.js
@@ -1,7 +1,8 @@
 /**
  * Preview will use preview.mobify.com to open a website and allow you to preview
  * a given bundle. The bundle and base URL will need to be set in the the
- * `tests/integration/site.json` file. Additionally, you can pass a URL as an
+ * `tests/system/site.json` file. If this file does not exist, 
+ * Additionally, you can pass a URL as an
  * argument when you call preview(). Upon completion, waitUntilMobified
  * is called, to be sure that the adaptation is complete.
  *
@@ -26,50 +27,57 @@
 
 
 var path = require('path');
-var site = require(path.join(path.resolve('./'), '/tests/system/site.json'));
+try {
+    var site = require(path.join(path.resolve('./'), '/tests/system/site.json'));
+} catch (e) {
+    if (e instanceof Error && e.code === 'MODULE_NOT_FOUND') {
+        console.log('Site.json does not exist, so .preview() is not available.');
+    }
+}
 var qs = require('querystring');
 
-site = site.profiles[site.activeProfile];
+if (site) { 
+    site = site.profiles[site.activeProfile];
 
-exports.command = function(url, callback) {
-    var browser = this;
+    exports.command = function(url, callback) {
+        var browser = this;
 
-    if (typeof url === 'function') {
-        callback = url;
-        url = site.siteUrl;
-    }
+        if (typeof url === 'function') {
+            callback = url;
+            url = site.siteUrl;
+        }
 
-    // First checks for the URL, otherwise uses the site.siteURL, then makes sure
-    // that there is an http prefix. The preveiw function doesn't need this, but
-    // the browser.get() method does.
-    url = url || site.siteUrl;
+        // First checks for the URL, otherwise uses the site.siteURL, then makes sure
+        // that there is an http prefix. The preveiw function doesn't need this, but
+        // the browser.get() method does.
+        url = url || site.siteUrl;
 
-    if (!url.match(/^http/)) {
-        throw new Error('Site URL must be correctly formatted');
-    }
+        if (!url.match(/^http/)) {
+            throw new Error('Site URL must be correctly formatted');
+        }
 
-    // If the production flag is set, just runs a `get()` on the URL.
-    if (site.production) {
-        return browser.get(url, function(result) {
-            if (typeof callback === 'function') {
-                callback.call(browser, result);
-            }
-        });
-    }
+        // If the production flag is set, just runs a `get()` on the URL.
+        if (site.production) {
+            return browser.get(url, function(result) {
+                if (typeof callback === 'function') {
+                    callback.call(browser, result);
+                }
+            });
+        }
 
-    var bundleUrl = site.bundleUrl || 'http://localhost:8080';
+        var bundleUrl = site.bundleUrl || 'http://localhost:8080';
 
-    var params = qs.stringify({'url': url, 'site_folder': bundleUrl});
+        var params = qs.stringify({'url': url, 'site_folder': bundleUrl});
 
-    return browser.url('https://preview.mobify.com?' + params)
-        .waitForElementPresent('#authorize', 10000, function() {
-            this.click('#authorize', function() {
-                browser.waitUntilMobified(10000, function(result) {
-                    if (typeof callback === 'function') {
-                        callback.call(browser, result);
-                    }
+        return browser.url('https://preview.mobify.com?' + params)
+            .waitForElementPresent('#authorize', 10000, function() {
+                this.click('#authorize', function() {
+                    browser.waitUntilMobified(10000, function(result) {
+                        if (typeof callback === 'function') {
+                            callback.call(browser, result);
+                        }
+                    });
                 });
             });
-        });
-
-};
+    };
+}

--- a/commands/preview.js
+++ b/commands/preview.js
@@ -81,7 +81,7 @@ exports.command = function(url, callback) {
                 });
             });
     } else {
-        return browser.get(url, function(result) {
+        return browser.url(url, function(result) {
             if (typeof callback === 'function') {
                 callback.call(browser, result);
             }

--- a/commands/preview.js
+++ b/commands/preview.js
@@ -66,7 +66,7 @@ exports.command = function(url, callback) {
             });
         }
 
-        var bundleUrl = site.bundleUrl || 'http://localhost:8080';
+        var bundleUrl = site.bundleUrl || 'https://localhost:8443/adaptive.js';
 
         var params = qs.stringify({'url': url, 'site_folder': bundleUrl});
 

--- a/commands/preview.js
+++ b/commands/preview.js
@@ -1,10 +1,11 @@
 /**
  * Preview will use preview.mobify.com to open a website and allow you to preview
  * a given bundle. The bundle and base URL will need to be set in the the
- * `tests/system/site.json` file. If this file does not exist, 
- * Additionally, you can pass a URL as an
+ * `tests/system/site.json` file. Additionally, you can pass a URL as an
  * argument when you call preview(). Upon completion, waitUntilMobified
  * is called, to be sure that the adaptation is complete.
+*
+ * If `site.json` does not exist, this command will just go to the specified URL. 
  *
  * ```
  *    this.demoTest = function (client) {
@@ -25,22 +26,22 @@
  * @api assertions
  */
 
-
 var path = require('path');
+
 try {
     var site = require(path.join(path.resolve('./'), '/tests/system/site.json'));
 } catch (e) {
     if (e instanceof Error && e.code === 'MODULE_NOT_FOUND') {
-        console.log('Site.json does not exist, so .preview() is not available.');
+        console.log('Not using optional site.json...');
     }
 }
 var qs = require('querystring');
 
-if (site) { 
-    site = site.profiles[site.activeProfile];
+exports.command = function(url, callback) {
+    var browser = this;
 
-    exports.command = function(url, callback) {
-        var browser = this;
+    if (site) { 
+        site = site.profiles[site.activeProfile];
 
         if (typeof url === 'function') {
             callback = url;
@@ -48,7 +49,7 @@ if (site) {
         }
 
         // First checks for the URL, otherwise uses the site.siteURL, then makes sure
-        // that there is an http prefix. The preveiw function doesn't need this, but
+        // that there is an http prefix. The preview function doesn't need this, but
         // the browser.get() method does.
         url = url || site.siteUrl;
 
@@ -79,5 +80,11 @@ if (site) {
                     });
                 });
             });
-    };
-}
+    } else {
+        return browser.get(url, function(result) {
+            if (typeof callback === 'function') {
+                callback.call(browser, result);
+            }
+        });
+    }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nightwatch-commands",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A set of Mobify specific custom commands for Nightwatch.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Status: **Ready for Review** 
Owner: Ellen
Reviewers: @mobify-derrick @marlowpayne @johnboxall 

## Changes
- `.preview()` command no longer throws an error if `tests/system/site.json` is not present
- `.preview()` with no `site.json` will just go to the specified URL
- `.preview()` command runs as it usually does if `tests/system/site.json` is present

## Related issues:
- [x] https://github.com/mobify/nightwatch-commands/issues/37

## Todos:
- [x] Engineer +1

### Feedback:
_none so far_

## How to Test
- In your `package.json`, `"nightwatch-commands": "git://github.com/mobify/nightwatch-commands#optional-site-json",`
- Delete `site.json` if you have it
- Run a test that uses `browser.preview()`