### PR TITLE
use siteConfig to refer to site.json file

### DIFF
--- a/commands/preview.js
+++ b/commands/preview.js
@@ -29,7 +29,7 @@
 var path = require('path');
 
 try {
-    var site = require(path.join(path.resolve('./'), '/tests/system/site.json'));
+    var siteConfig = require(path.join(path.resolve('./'), '/tests/system/site.json'));
 } catch (e) {
     if (e instanceof Error && e.code === 'MODULE_NOT_FOUND') {
         console.log('Not using optional site.json...');
@@ -40,8 +40,8 @@ var qs = require('querystring');
 exports.command = function(url, callback) {
     var browser = this;
 
-    if (site) { 
-        site = site.profiles[site.activeProfile];
+    if (siteConfig) { 
+        var site = siteConfig.profiles[siteConfig.activeProfile];
 
         if (typeof url === 'function') {
             callback = url;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nightwatch-commands",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "A set of Mobify specific custom commands for Nightwatch.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Status: **Ready for Review** 
Owner: Ellen
Reviewers: @mobify-derrick 

## Changes
- Fixes (??) an issue introduced in 1.3.1 where `.preview()` will throw an error if called more than once in a test suite

## Todos:
- [x] Engineer +1

### Feedback:
_none so far_

## How to Test
- Use this branch in your project: `"nightwatch-commands": "git+ssh://git@github.com:mobify/nightwatch-commands.git#1.3.2",`
- Ensure test suites that call `.preview()` more than once still work