### PR TITLE
add waitForUrlToContain command

### DIFF
--- a/commands/waitForUrlToContain.js
+++ b/commands/waitForUrlToContain.js
@@ -1,0 +1,81 @@
+var util = require('util'),
+    events = require('events');
+
+function WaitForUrlToContain() {
+    events.EventEmitter.call(this);
+    this.startTimer = null;
+    this.cb = null;
+    this.ms = null;
+    this.selector = null;
+    this.protocol = require('nightwatch/lib/api/protocol.js')(this.client);
+}
+
+util.inherits(WaitForUrlToContain, events.EventEmitter);
+
+/**
+ * Waiting for url expected
+ * @param  {[type]} url [url expected]
+ * @param  {[type]} milliseconds [time for close assert]
+ * @param  {[type]} timeout [time verify]
+ * @param  {[type]} messages [message output]
+ * @param  {Function} callback [callback]
+ * @return {[type]} [client]
+ */
+WaitForUrlToContain.prototype.command = function(url, milliseconds, timeout, messages, callback) {
+
+    if (milliseconds && typeof milliseconds !== 'number') {
+        throw new Error('waitForCondition expects second parameter to be number; ' + typeof (milliseconds) + ' given');
+    }
+
+    var lastArgument = Array.prototype.slice.call(arguments, 0).pop();
+    if (typeof (lastArgument) === 'function') {
+        callback = lastArgument;
+    }
+
+    if (!messages || typeof messages !== 'object') {
+        messages = {
+            success: 'Url expected after ',
+            timeout: 'Timed out while waiting for url after '
+        };
+    }
+
+    timeout = timeout && typeof (timeout) !== 'function' && typeof (timeout) !== 'object' ? timeout : 0;
+
+    this.startTimer = new Date().getTime();
+    this.cb = callback || function() {
+    };
+    this.ms = milliseconds || 1000;
+    this.timeout = timeout;
+    this.url = url;
+    this.messages = messages;
+    this.check();
+    return this;
+};
+
+WaitForUrlToContain.prototype.check = function() {
+    var self = this;
+
+    this.protocol.url(function(result) {
+        var now = new Date().getTime();
+
+        if (result.status === 0 && (result.value.indexOf(self.url) > -1)) {
+            setTimeout(function() {
+                var msg = self.messages.success + (now - self.startTimer) + ' milliseconds.';
+                self.cb.call(self.client.api, result.value);
+                self.client.assertion(true, !!result.value, false, msg, true);
+                return self.emit('complete');
+            }, self.timeout);
+        } else if (now - self.startTimer < self.ms) {
+            setTimeout(function() {
+                self.check();
+            }, 500);
+        } else {
+            var msg = self.messages.timeout + self.ms + ' milliseconds.';
+            self.cb.call(self.client.api, false);
+            self.client.assertion(false, false, false, msg, true);
+            return self.emit('complete');
+        }
+    });
+};
+
+module.exports = WaitForUrlToContain;

--- a/commands/waitForUrlToContain.js
+++ b/commands/waitForUrlToContain.js
@@ -44,7 +44,7 @@ WaitForUrlToContain.prototype.command = function(url, milliseconds, timeout, mes
     this.startTimer = new Date().getTime();
     this.cb = callback || function() {
     };
-    this.ms = milliseconds || 1000;
+    this.ms = milliseconds || 10000;
     this.timeout = timeout;
     this.url = url;
     this.messages = messages;


### PR DESCRIPTION
Status: **Ready for Review** 
Owner: Ellen 
Reviewers: @RobotRogue @twangtina @gsaray @lilyzh @mobify-derrick @marlowpayne 

## Changes
- Adds command `.waitForUrlToContain('url', milliseconds, timeout, messages, callback)` that waits for `milliseconds` milliseconds for the page URL to contain `url`. Default is to wait 10000 ms. 

## Todos:
- [ ] Engineer +1 

### Feedback:
- [x] Increase default timeout to 10000

## How to Test
- in your `package.json`, `"nightwatch-commands": "git://github.com/mobify/nightwatch-commands.git#waitForUrlToContain",`