### PR TITLE
Adjust linting targets to capture more of our source code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ Pending Release
     - Follow company practices for tools and gitflow
     - Have CircleCI lint our source code (TODO: tests to be fixed later)
     - Update JS linting to current standards (grunt-eslint ^17.0.0 & mobify-code-style ^2.3.6)
+    - Fine tune linting targets to capture as much source code as feasible
 1.4.0
     - Introduces the command `waitForUrl`
 1.3.2

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,10 +1,10 @@
 module.exports = function(grunt) {
     var targets = [
-        'Gruntfile.js',
-        'assertions/**/*.js',
-        'commands/**/*.js',
-        'tests/**/*.js',
-        '!tests/node_modules/**'
+        '*.js',
+        '**/*.js',
+        '!node_modules/**',
+        '!tests/node_modules/**',
+        '!selenium/**'
     ];
 
     grunt.loadNpmTasks('grunt-eslint');


### PR DESCRIPTION
Status: **Ready for Review**
Owner: @marlowpayne
Reviewers: @mobify-derrick @ellenmobify 

## Changes
- Instead of having to whitelist all of our linting targets, let's instead lint _all_ JS and blacklist code that's beyond our source code's scope (selenium installation JS, node modules' JS, etc)

## Todos:
- [x] +1

### Feedback:
_none so far_

## How to Test
- Checkout code
- `npm test`
- Make a deliberate JS error and make sure the linter catches it