### PR TITLE
Add support for site.js

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,9 +7,9 @@ Reviewers: @ellenmobify @marlowpayne @mobify-derrick
 - (change2)
 
 ## Todos:
-- [] Passed linting check (run `grunt lint`)
-- [] Updated README
-- [] Updated CHANGELOG
+- [ ] Passed linting check (run `grunt lint`)
+- [ ] Updated README
+- [ ] Updated CHANGELOG
 
 ### Feedback:
 _none so far_

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+1.6.0
+    - Update `preview` command to accept an optional `site.js`.
 1.5.0
     - Follow company practices for tools and gitflow
     - Have CircleCI lint our source code (TODO: tests to be fixed later)

--- a/README.md
+++ b/README.md
@@ -166,9 +166,59 @@ this.demoTest = function (browser) {
 
 #### preview(url, callback)
 
-The `preview` command uses http://preview.mobify.com to open a website to preview a given bundle. The bundle and the base URL need to be set in the `tests/system/site.json` file. Note that if the "production" flag is set in `site.json`, the bundle URL will be ignored. Pass in an optional URL as an argument to this command. Upon completion, `waitUntilMobified` is called to ensure that the mobile site adaptation is complete.
+The `preview` command uses http://preview.mobify.com to open a website to preview a given bundle. The bundle and the base URL need to be set in the `tests/system/site.json` or `tests/system/site.js` file. Note that if the "production" flag is set in the `activeProfile` in `site.json` or `site.js`, the bundle URL will be ignored. Pass in an optional URL as an argument to this command. Upon completion, `waitUntilMobified` is called to ensure that the mobile site adaptation is complete.
 
-If the project does not have a `tests/system/site.json` file, this command is equivalent to the `url` protocol command. 
+Example site.json
+```
+{
+    "activeProfile": "production",
+    "profiles": {
+        "default": {
+            "bundleUrl": "http://localhost:8080/adaptive.js",
+            "siteUrl": "http://www.merlinspotions.com/"
+        },
+        "production": {
+            "bundleUrl": "",
+            "siteUrl": "http://www.merlinspotions.com/",
+            "production": true
+        }
+    }
+}
+```
+
+Example site.js
+```
+var Site = {
+    /*
+     activeProfile defines which environment to run tests against.
+     By default, builds on master branch run against production, without preview.
+     Builds on any other branch should use preview with local adaptive.js.
+
+     Change activeProfile whenever you need to override the default behaviour.
+    */
+    activeProfile: process.env.ACTIVE_PROFILE || 'default',
+
+    /*
+     Define new profiles as needed for different URLs, eg. staging, prod.
+    */
+    profiles: {
+        default: {
+            bundleUrl: 'http://localhost:8080/adaptive.js',
+            siteUrl: 'http://www.merlinspotions.com/'
+        },
+        production: {
+            bundleUrl: '',
+            siteUrl: 'http://www.merlinspotions.com',
+            production: true
+        }
+    }
+};
+
+module.exports = Site;
+
+```
+
+If the project does not have a `site.json` or `site.js` file, this command is equivalent to the `url` protocol command. 
 
 Parameter Name | Parameter Type | Description
 -------------  | -------------- | -----------

--- a/commands/preview.js
+++ b/commands/preview.js
@@ -32,9 +32,18 @@ try {
     var siteConfig = require(path.join(path.resolve('./'), '/tests/system/site.json'));
 } catch (e) {
     if (e instanceof Error && e.code === 'MODULE_NOT_FOUND') {
-        console.log('Not using optional site.json...');
+        console.log('Not using optional site.json. Looking for site.js...');
     }
 }
+
+try {
+    var siteConfig = require(path.join(path.resolve('./'), '/tests/system/site.js'));
+} catch (e) {
+    if (e instanceof Error && e.code === 'MODULE_NOT_FOUND') {
+        console.log('Not using optional site.js.');
+    }
+}
+
 var qs = require('querystring');
 
 exports.command = function(url, callback) {


### PR DESCRIPTION
Status: **Ready for Review**
Owner: Ellen
Reviewers: @marlowpayne @mobify-derrick

## Changes
- Updates `preview` command to support a `site.js` file, as used in https://github.com/mobify/blackcircles-mobile/pull/23

## Todos:
- [x] Passed linting check (run `grunt lint`)
- [x] Updated README
- [x] Updated CHANGELOG

### Feedback:
_none so far_

## How To Test
- Checkout this branch
- `npm install`
- `npm link`
- `grunt lint`
- (notes)
