### PR TITLE
Bugfix for waitForAjaxCompleted

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+1.6.3
+    - Fixes a bug in `waitForAjaxCompleted` in cases where `$` is not bound to jQuery.
 1.6.2
     - Update `preview` command to accept `site.js` files under `/system/site.js`
 1.6.1

--- a/commands/waitForAjaxCompleted.js
+++ b/commands/waitForAjaxCompleted.js
@@ -3,7 +3,7 @@ exports.command = function(callback) {
 
     // Uses waitForCondition to run code within the client browser
     //
-    return client.waitForCondition('return $.active;', 8000, function(result) {
+    return client.waitForCondition('return jQuery.active;', 8000, function(result) {
         if (typeof callback === 'function') {
             callback.call(client, result);
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nightwatch-commands",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "A set of Mobify specific custom commands for Nightwatch.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Status: **Ready for Review** or **Open for Visibility**
Owner: @ellenmobify
Reviewers:  @marlowpayne @mikenikles 

## Changes
- Fixes a bug in `waitForAjaxCompleted` which would fail if `$` was not bound to jQuery

## Todos:
- [x] Passed linting check (run `grunt lint`)
- [x] Updated README
- [x] Updated CHANGELOG

### Feedback:
_none so far_

## How To Test
- Checkout this branch
- `npm install`
- `npm link`
- `grunt lint`
- Test on projects like https://github.com/mobify/garnet-hill-mobile 
