### PR TITLE
update selenium download to 2.0.10

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 2.0.1
     -Update [selenium-download](https://github.com/groupon/selenium-download) to 2.0.10
-
+        - selenium chromedriver 2.29
+        - selenium standalone server 3.4.0
 2.0.0
     - Use [selenium-download](https://github.com/groupon/selenium-download) to manage downloading of Selenium server and Chromedriver. 
     - BREAKING CHANGES

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2.0.1
+    -Update [selenium-download](https://github.com/groupon/selenium-download) to 2.0.10
+
 2.0.0
     - Use [selenium-download](https://github.com/groupon/selenium-download) to manage downloading of Selenium server and Chromedriver. 
     - BREAKING CHANGES

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ To begin, clone this repository. `cd` into your chosen folder, and run the follo
 
 Selenium server and Chromedriver will also be downloaded into `/selenium`. 
 
+Currently Using https://www.npmjs.com/package/selenium-download version: 2.0.10
+
 ### Linting
 JavaScript in this tool is linted with [ESLint](http://eslint.org/) according to our code [syntax and style standards](https://github.com/mobify/mobify-code-style) here at Mobify.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ To begin, clone this repository. `cd` into your chosen folder, and run the follo
 Selenium server and Chromedriver will also be downloaded into `/selenium`. 
 
 Currently Using https://www.npmjs.com/package/selenium-download version: 2.0.10
+        - selenium chromedriver 2.29
+        - selenium standalone server 3.4.0
 
 ### Linting
 JavaScript in this tool is linted with [ESLint](http://eslint.org/) according to our code [syntax and style standards](https://github.com/mobify/mobify-code-style) here at Mobify.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "async": "0.2.10",
     "chalk": "0.4.0",
     "mkdirp": "0.5.1",
-    "selenium-download": "2.0.6"
+    "selenium-download": "2.0.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nightwatch-commands",
-  "version": "1.8.0",
+  "version": "2.0.1",
   "description": "A set of Mobify specific custom commands for Nightwatch.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Status: **Ready for Review**
Owner: @jasecode
Reviewers: @ellenmobify 

## Changes
- package.json bumped "selenium-download": "2.0.10"

## Todos:
- [x] Passed linting check (run `grunt lint`)
- [x] Updated README
- [x] Updated CHANGELOG

### Feedback:
_none so far_

## How To Test
- Checkout this branch
- `npm install`
- `npm link`

Test in another Project (platform-scaffold has been done already)
- In it's package.json, change the nightwatch-commands line to "nightwatch-commands": "mobify/nightwatch-commands#upgrade-selenium", then run the end-to-end tests. 